### PR TITLE
Add compatibility with archlinux for releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -29,7 +29,7 @@ sed -e"s/(gr_text \"tomu.im  $CURRENT_VERSION\"/(gr_text \"tomu.im  $NEXT_VERSIO
 git add tomu.kicad_pcb
 
 # Generate the gerber files
-python third_party/gen_gerber_and_drill_files_board.py tomu.kicad_pcb $OUTDIR/gerbers
+python2 third_party/gen_gerber_and_drill_files_board.py tomu.kicad_pcb $OUTDIR/gerbers
 git add $OUTDIR/gerbers/*
 
 git commit -m "Bumping version to $NEXT_VERSION"


### PR DESCRIPTION
As defined in PEP 394 the version of python should be
specified when executing a script, due to archlinux
and similar distributions pointing python to python3
rather than python2. gen_gerber_and_drill_files_board.py
is written in python 2 therefore won't work on archlinux
and similar distributions.